### PR TITLE
Allow running NFS without locking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/terricain/truenas-scale-csi
+          images: ghcr.io/${{ github.repository_owner }}/truenas-scale-csi
           labels: |
             org.opencontainers.image.authors=Terry Cain
             org.opencontainers.image.title=TrueNAS Scale CSI Driver

--- a/charts/truenas-scale-csi/templates/node.yaml
+++ b/charts/truenas-scale-csi/templates/node.yaml
@@ -116,6 +116,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: DRIVER_NAME
               value: {{ include "truenas-scale-csi.csiDriverName" . | quote }}
+            - name: NFS_NOLOCK
+              value: {{ .Values.node.nfsNoLock | quote }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/truenas-scale-csi/values.yaml
+++ b/charts/truenas-scale-csi/values.yaml
@@ -107,6 +107,7 @@ node:
     capabilities:
       add: [ "SYS_ADMIN" ]
   resources: {}
+  nfsNoLock: false # Set to true if you want to run NFS without locking, not recommended.
 
 nfsCSIDriverName: "nfs.truenas-scale.terricain.github.com"
 iscsiCSIDriverName: "iscsi.truenas-scale.terricain.github.com"

--- a/pkg/driver/nfs.go
+++ b/pkg/driver/nfs.go
@@ -344,6 +344,11 @@ func (d *Driver) nfsNodePublishVolume(ctx context.Context, req *csi.NodePublishV
 		mountOptions = append(mountOptions, "ro")
 	}
 
+	// Conditionally allow nolock if specified by environment variable
+	if os.Getenv("NFS_NOLOCK") == "true" {
+		mountOptions = append(mountOptions, "nolock")
+	}
+
 	var server, baseDir string
 	for k, v := range req.GetVolumeContext() {
 		switch k {


### PR DESCRIPTION
If running certain Kubernetes distributions file locking may not be supported on nfs. This allows it to be optionally disabled